### PR TITLE
Fix localstorage logic bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-styled-components-dark-mode",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A Gatsby plugin for toggling dark mode and injecting themes using styled-components",
   "main": "index.js",
   "scripts": {

--- a/src/ThemeManager.tsx
+++ b/src/ThemeManager.tsx
@@ -31,10 +31,10 @@ export const ThemeManagerProvider = (props: Props) => {
   };
 
   useEffect(() => {
-    const localStorageTheme = localStorage.getItem("dark");
-    const latestTheme = localStorageTheme && JSON.parse(localStorageTheme);
-    if (latestTheme) {
-      setIsDark(latestTheme);
+    const themeFromLocalStorage = localStorage.getItem("dark");
+
+    if (typeof themeFromLocalStorage === 'string') {
+      setIsDark(JSON.parse(themeFromLocalStorage));
     } else if (supportsDarkMode()) {
       setIsDark(true);
     }


### PR DESCRIPTION
Fixes #7 

This fixes an issue in the logic for checking and correctly setting the previously chosen theme in `ThemeManager.tsx`. 

The problem was that we were checking if a previous theme existed by using the existence of a null coalescing variable that evaluated to a boolean. Hence, `{ dark: false }` (which equates to *light theme*) turns into `false`, which evaluates to `if (false) { /** ... **/ }`; this then would default to the `supportsDarkMode()` branch in the if-statement.

Thank you @IonutMorariu for finding this.