### PR TITLE
Added handling for system dark mode setting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,7 +158,7 @@ const MyLightOrDarkStyledComponent = styled.div`
 
 ### Toggling the theme
 
-Somewhere in your app, you'll want to provide functionality to actually change the theme from one theme to the other.
+Somewhere in your app, you'll want to provide functionality to actually change the theme from one theme to the other, or to respect the current system dark mode setting.
 
 The plugin exposes this functionality through `ThemeManagerContext`
 
@@ -168,8 +168,10 @@ Consuming the context will get you access to
 | --- | --- | --- |
 | isDark | boolean | state that describes if your app is in dark mode or not |
 | toggleDark | (value?: boolean) => void | function that toggles dark/light mode |
+| themeSetting | ThemeSetting | the current theme setting - either LIGHT, DARK or SYSTEM |
+| changeThemeSetting | (setting: ThemeSetting) => void | function that allows setting dark mode, light mode or system-setting mode |
 
-#### Example
+#### Example - light/dark mode toggle
 
 in a presumed `src/component/layout.tsx`
 ```javascript
@@ -187,6 +189,52 @@ export const Layout = (props) => {
           checked={themeContext.isDark}
         />{" "}
         Dark mode
+      </label>
+    </div>
+  )
+}
+```
+
+#### Example - light/dark/system mode toggle
+
+in a presumed `src/component/layout.tsx`
+```javascript
+import { ThemeManagerContext, ThemeSetting } from "gatsby-styled-components-dark-mode"
+
+export const Layout = (props) => {
+  const themeContext = useContext(ThemeManagerContext)
+  const onThemeSettingChanged = (ev) => themeContext.changeThemeSetting(ev.target.value)
+
+  return (
+    <div>
+      <label>
+        <input
+          type="radio"
+          value={ThemeSetting.LIGHT}
+          onChange={onThemeSettingChanged}
+          checked={themeContext.themeSetting == ThemeSetting.LIGHT}
+        />{" "}
+        Light mode
+      </label>
+      <br/>
+      <label>
+        <input
+          type="radio"
+          value={ThemeSetting.DARK}
+          onChange={onThemeSettingChanged}
+          checked={themeContext.themeSetting == ThemeSetting.DARK}
+        />{" "}
+        Dark mode
+      </label>
+      <br/>
+      <label>
+        <input
+          type="radio"
+          value={ThemeSetting.SYSTEM}
+          onChange={onThemeSettingChanged}
+          checked={themeContext.themeSetting == ThemeSetting.SYSTEM}
+        />{" "}
+        Use system setting
       </label>
     </div>
   )

--- a/src/ThemeManager.tsx
+++ b/src/ThemeManager.tsx
@@ -5,46 +5,98 @@ interface Props {
   children: ReactNode;
 }
 
+export enum ThemeSetting {
+  LIGHT = 'LIGHT',
+  DARK = 'DARK',
+  SYSTEM = 'SYSTEM',
+}
+
+const DarkThemeKey = 'dark';
+
 interface ThemeManager {
   isDark: boolean;
-
   toggleDark(value?: boolean): void;
+  
+  themeSetting: ThemeSetting;
+  changeThemeSetting: (setting: ThemeSetting) => void;
 }
 
 const defaultState: ThemeManager = {
   isDark: false,
-  toggleDark: () => undefined
+  toggleDark: () => undefined,
+  
+  themeSetting: ThemeSetting.SYSTEM,
+  changeThemeSetting: (_: ThemeSetting) => undefined,
 };
 
 export const ThemeManagerContext = createContext(defaultState);
 
-const supportsDarkMode = () =>
-  window.matchMedia("(prefers-color-scheme: dark)").matches;
+const systemDarkModeSetting = () => window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+const isDarkModeActive = () => {
+  // Assume that dark mode is not active if there's no system dark mode setting available
+  if (systemDarkModeSetting()?.matches) {
+    return true;
+  }
+
+  return false;
+};
 
 export const ThemeManagerProvider = (props: Props) => {
   const [isDark, setIsDark] = useState(false);
+  const [themeSetting, setThemeSetting] = useState(ThemeSetting.SYSTEM);
 
   const toggleDark = (value?: boolean) => {
     const toggledTheme = value ?? !isDark;
-    setIsDark(toggledTheme);
-    localStorage.setItem("dark", JSON.stringify(toggledTheme));
+    setThemeSetting(toggledTheme ? ThemeSetting.DARK : ThemeSetting.LIGHT);
+  };
+
+  const changeThemeSetting = (setting: ThemeSetting) => {
+    setThemeSetting(setting);
+    localStorage.setItem(DarkThemeKey, setting);
   };
 
   useEffect(() => {
-    const themeFromLocalStorage = localStorage.getItem("dark");
+    // Add a listener to the dark mode setting
+    const listener = (e: MediaQueryListEvent) => {
+      if (themeSetting == ThemeSetting.SYSTEM) {
+        setIsDark(e.matches);
+      }
+    };
+
+    systemDarkModeSetting()?.addListener(listener);
+    return () => systemDarkModeSetting()?.removeListener(listener);
+  }, []);
+
+  useEffect(() => {
+    // Set dark mode to active if the theme setting is specifically dark, or if the current system setting for dark mode is active
+    setIsDark(themeSetting == ThemeSetting.DARK || !!(themeSetting == ThemeSetting.SYSTEM && isDarkModeActive()));
+  }, [themeSetting]);
+
+  useEffect(() => {
+    const themeFromLocalStorage = localStorage.getItem(DarkThemeKey);
 
     if (typeof themeFromLocalStorage === 'string') {
-      setIsDark(JSON.parse(themeFromLocalStorage));
-    } else if (supportsDarkMode()) {
-      setIsDark(true);
+      if (themeFromLocalStorage in ThemeSetting) {
+        setThemeSetting(themeFromLocalStorage as ThemeSetting);
+      } else {
+        // Fallback if the stored theme is the legacy "true"/"false"
+        setThemeSetting(JSON.parse(themeFromLocalStorage) ? ThemeSetting.DARK : ThemeSetting.LIGHT);
+      }
+
+      return;
     }
+
+    // If there's no stored setting, set the theme to use the system's current setting
+    changeThemeSetting(isDarkModeActive() ? ThemeSetting.DARK : ThemeSetting.LIGHT);
   }, []);
 
   return (
     <ThemeManagerContext.Provider
       value={{
         isDark,
-        toggleDark
+        toggleDark,
+        themeSetting,
+        changeThemeSetting,
       }}
     >
       {props.children}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import { ThemeManagerContext } from "./ThemeManager"
+import { ThemeManagerContext, ThemeSetting } from "./ThemeManager"
 
-export { ThemeManagerContext }
+export { ThemeManagerContext, ThemeSetting }


### PR DESCRIPTION
- Add a third dark mode setting for respecting the system’s dark mode setting
- Listen for changes in system dark mode setting and change dark mode theme accordingly, if the “system” dark mode setting is enabled

**NOTE**: This change should be backwards-compatible with the old true/false dark mode toggle setting.