### PR TITLE
Fix flash

### DIFF
--- a/src/InitialBootLoader.tsx
+++ b/src/InitialBootLoader.tsx
@@ -1,0 +1,22 @@
+import React, { ReactNode, useEffect, useState } from "react";
+import { ThemeManagerContext } from "./ThemeManager";
+
+interface InitialBootLoaderProps {
+  children: ReactNode;
+}
+
+export function InitialBootLoader(props: InitialBootLoaderProps) {
+  const context = React.useContext(ThemeManagerContext);
+  const [didLoad, setDidLoad] = useState(false);
+
+  useEffect(() => {
+    context.initThemeFromStorage();
+    setDidLoad(true);
+  }, []);
+
+  if (!didLoad) {
+    return null;
+  }
+
+  return <>{props.children}</>;
+}

--- a/src/ThemeManager.tsx
+++ b/src/ThemeManager.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { createContext, useEffect, useState, ReactNode } from "react";
+import { createContext, useState, ReactNode, useEffect } from "react";
 
 interface Props {
   children: ReactNode;
@@ -16,7 +16,7 @@ const DarkThemeKey = 'dark';
 interface ThemeManager {
   isDark: boolean;
   toggleDark(value?: boolean): void;
-  
+
   themeSetting: ThemeSetting;
   changeThemeSetting: (setting: ThemeSetting) => void;
 }
@@ -24,7 +24,7 @@ interface ThemeManager {
 const defaultState: ThemeManager = {
   isDark: false,
   toggleDark: () => undefined,
-  
+
   themeSetting: ThemeSetting.SYSTEM,
   changeThemeSetting: (_: ThemeSetting) => undefined,
 };
@@ -34,11 +34,7 @@ export const ThemeManagerContext = createContext(defaultState);
 const systemDarkModeSetting = () => window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
 const isDarkModeActive = () => {
   // Assume that dark mode is not active if there's no system dark mode setting available
-  if (systemDarkModeSetting()?.matches) {
-    return true;
-  }
-
-  return false;
+  return !!systemDarkModeSetting()?.matches;
 };
 
 export const ThemeManagerProvider = (props: Props) => {
@@ -46,48 +42,42 @@ export const ThemeManagerProvider = (props: Props) => {
   const [themeSetting, setThemeSetting] = useState(ThemeSetting.SYSTEM);
 
   const toggleDark = (value?: boolean) => {
-    const toggledTheme = value ?? !isDark;
-    setThemeSetting(toggledTheme ? ThemeSetting.DARK : ThemeSetting.LIGHT);
+    const newIsDark = value ?? !isDark
+    const theme = newIsDark ? ThemeSetting.DARK : ThemeSetting.LIGHT
+    setIsDark(newIsDark)
+    setThemeSetting(theme)
+    localStorage.setItem(DarkThemeKey, theme)
   };
 
   const changeThemeSetting = (setting: ThemeSetting) => {
-    setThemeSetting(setting);
-    localStorage.setItem(DarkThemeKey, setting);
-  };
-
-  useEffect(() => {
-    // Add a listener to the dark mode setting
-    const listener = (e: MediaQueryListEvent) => {
-      if (themeSetting == ThemeSetting.SYSTEM) {
-        setIsDark(e.matches);
+    switch (setting) {
+      case ThemeSetting.SYSTEM: {
+        setIsDark(isDarkModeActive())
+        break
       }
-    };
-
-    systemDarkModeSetting()?.addListener(listener);
-    return () => systemDarkModeSetting()?.removeListener(listener);
-  }, []);
-
-  useEffect(() => {
-    // Set dark mode to active if the theme setting is specifically dark, or if the current system setting for dark mode is active
-    setIsDark(themeSetting == ThemeSetting.DARK || !!(themeSetting == ThemeSetting.SYSTEM && isDarkModeActive()));
-  }, [themeSetting]);
+      case ThemeSetting.LIGHT:
+      case ThemeSetting.DARK:
+        setIsDark(setting === ThemeSetting.DARK)
+    }
+    setThemeSetting(setting);
+    localStorage.setItem(DarkThemeKey, setting)
+  }
 
   useEffect(() => {
     const themeFromLocalStorage = localStorage.getItem(DarkThemeKey);
 
-    if (typeof themeFromLocalStorage === 'string') {
-      if (themeFromLocalStorage in ThemeSetting) {
-        setThemeSetting(themeFromLocalStorage as ThemeSetting);
-      } else {
-        // Fallback if the stored theme is the legacy "true"/"false"
-        setThemeSetting(JSON.parse(themeFromLocalStorage) ? ThemeSetting.DARK : ThemeSetting.LIGHT);
-      }
+    if (!themeFromLocalStorage) {
+      setIsDark(isDarkModeActive())
 
-      return;
+      return
     }
 
-    // If there's no stored setting, set the theme to use the system's current setting
-    changeThemeSetting(isDarkModeActive() ? ThemeSetting.DARK : ThemeSetting.LIGHT);
+    if (themeFromLocalStorage in ThemeSetting) {
+      changeThemeSetting(themeFromLocalStorage as ThemeSetting)
+    } else {
+      // Fallback if the stored theme is the legacy "true"/"false"
+      changeThemeSetting(JSON.parse(themeFromLocalStorage) ? ThemeSetting.DARK : ThemeSetting.LIGHT)
+    }
   }, []);
 
   return (

--- a/src/ThemeManager.tsx
+++ b/src/ThemeManager.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { createContext, useState, ReactNode, useEffect } from "react";
+import { createContext, useState, ReactNode } from "react";
 
 interface Props {
   children: ReactNode;
@@ -15,10 +15,10 @@ const DarkThemeKey = 'dark';
 
 interface ThemeManager {
   isDark: boolean;
-  toggleDark(value?: boolean): void;
-
   themeSetting: ThemeSetting;
+  toggleDark(value?: boolean): void;
   changeThemeSetting: (setting: ThemeSetting) => void;
+  initThemeFromStorage: () => void
 }
 
 const defaultState: ThemeManager = {
@@ -27,6 +27,7 @@ const defaultState: ThemeManager = {
 
   themeSetting: ThemeSetting.SYSTEM,
   changeThemeSetting: (_: ThemeSetting) => undefined,
+  initThemeFromStorage: () => undefined
 };
 
 export const ThemeManagerContext = createContext(defaultState);
@@ -63,7 +64,7 @@ export const ThemeManagerProvider = (props: Props) => {
     localStorage.setItem(DarkThemeKey, setting)
   }
 
-  useEffect(() => {
+  const initThemeFromStorage = () => {
     const themeFromLocalStorage = localStorage.getItem(DarkThemeKey);
 
     if (!themeFromLocalStorage) {
@@ -78,7 +79,7 @@ export const ThemeManagerProvider = (props: Props) => {
       // Fallback if the stored theme is the legacy "true"/"false"
       changeThemeSetting(JSON.parse(themeFromLocalStorage) ? ThemeSetting.DARK : ThemeSetting.LIGHT)
     }
-  }, []);
+  }
 
   return (
     <ThemeManagerContext.Provider
@@ -87,6 +88,7 @@ export const ThemeManagerProvider = (props: Props) => {
         toggleDark,
         themeSetting,
         changeThemeSetting,
+        initThemeFromStorage
       }}
     >
       {props.children}

--- a/src/gatsby-ssr.ts
+++ b/src/gatsby-ssr.ts
@@ -1,1 +1,3 @@
 export const wrapRootElement = require("./wrapRootElement").wrapRootElement;
+
+export const onRenderBody = require("./onRenderBody").onRenderBody;

--- a/src/wrapRootElement.tsx
+++ b/src/wrapRootElement.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import { StyledThemeProvider } from "./StyledThemeProvider";
 import { ThemeManagerProvider } from "./ThemeManager";
+import { InitialBootLoader } from "./InitialBootLoader";
 
 interface ThemeConfigProps {
   dark?: object;
@@ -19,9 +20,11 @@ export const wrapRootElement = (
 
   return (
     <ThemeManagerProvider>
-      <StyledThemeProvider lightTheme={light} darkTheme={dark}>
-        {gatsbyRootProps.element}
-      </StyledThemeProvider>
+      <InitialBootLoader>
+        <StyledThemeProvider lightTheme={light} darkTheme={dark}>
+          {gatsbyRootProps.element}
+        </StyledThemeProvider>
+      </InitialBootLoader>
     </ThemeManagerProvider>
   );
 };


### PR DESCRIPTION
Fixes flash caused by this plugin by deferring the children to only load after `initThemeFromStorage` runs. Also did some cleanup in `ThemeManager.tsx` to make it more readable and concise.

I also noticed while testing that other assets like fonts and other styling were causing delays in page load. A few things I did in my host application:
- Leveraged [gatsby-plugin-preload-fonts](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preload-fonts) to have heavy assets pre-loaded
- Removed transitions on page load

If **this plugin** is still the culprit for page flashes, please raise an issue or feel free to make a PR.

Closes #20 